### PR TITLE
Allow ssl connection

### DIFF
--- a/pkg/ysql/ysql.go
+++ b/pkg/ysql/ysql.go
@@ -34,7 +34,7 @@ func ExecuteYSQL(ctx context.Context, settings models.Settings, query models.Que
 		return nil, err
 	}
 
-	connection := fmt.Sprintf("host='%s' port='%s' database='%s' user='%s' password='%s' sslmode='disable'", host, port, settings.Database, settings.User, settings.Password)
+	connection := fmt.Sprintf("host='%s' port='%s' database='%s' user='%s' password='%s' sslmode='allow'", host, port, settings.Database, settings.User, settings.Password)
 
 	db, err := sql.Open("pgx", connection)
 	if err != nil {


### PR DESCRIPTION
in order to support connections to YugabyteDB Cloud, we need to allow ssl as this is required.