### PR TITLE
Add unit tests for core functionality

### DIFF
--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -12,13 +12,13 @@ type QueryModel struct {
 	RawSql    string `json:"rawSql"`
 }
 
-func LoadQuery(ctx context.Context, dataQuery backend.DataQuery) (*QueryModel, error) {
+func LoadQuery(ctx context.Context, dataQuery backend.DataQuery) (QueryModel, error) {
 	var query QueryModel
 
 	err := json.Unmarshal(dataQuery.JSON, &query)
 	if err != nil {
-		return nil, err
+		return QueryModel{}, err
 	}
 
-	return &query, nil
+	return query, nil
 }

--- a/pkg/models/query_test.go
+++ b/pkg/models/query_test.go
@@ -19,11 +19,6 @@ func TestLoadQuery(t *testing.T) {
 			t.Errorf("Unexpected error: %v", err)
 		}
 
-		if query == nil {
-			t.Error("Expected non-nil query")
-			return
-		}
-
 		if query.RawSql != expected.RawSql {
 			t.Errorf("Unexpected query. Expected: %s, got: %s", expected.RawSql, query.RawSql)
 		}

--- a/pkg/models/query_test.go
+++ b/pkg/models/query_test.go
@@ -16,7 +16,7 @@ func TestLoadQuery(t *testing.T) {
 
 		query, err := LoadQuery(ctx, dataQuery)
 		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
+			t.Error(err)
 		}
 
 		if query.RawSql != expected.RawSql {

--- a/pkg/models/query_test.go
+++ b/pkg/models/query_test.go
@@ -1,0 +1,42 @@
+package models
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+func TestLoadQuery(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Returns query with correct values", func(t *testing.T) {
+		dataQuery := backend.DataQuery{JSON: []byte(`{"rawSql": "SELECT 42;"}`)}
+		expected := &QueryModel{RawSql: "SELECT 42;"}
+
+		query, err := LoadQuery(ctx, dataQuery)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		if query == nil {
+			t.Error("Expected non-nil query")
+			return
+		}
+
+		if query.RawSql != expected.RawSql {
+			t.Errorf("Unexpected query. Expected: %s, got: %s", expected.RawSql, query.RawSql)
+		}
+	})
+
+	t.Run("Returns error when JSON unmarshal fails", func(t *testing.T) {
+		dataQuery := backend.DataQuery{
+			JSON: []byte(`invalid json`),
+		}
+
+		_, err := LoadQuery(ctx, dataQuery)
+		if err == nil {
+			t.Error("Expected error")
+		}
+	})
+}

--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -14,16 +14,16 @@ type Settings struct {
 	Password string
 }
 
-func LoadSettings(ctx context.Context, dsSettings backend.DataSourceInstanceSettings) (*Settings, error) {
-	settings := &Settings{
+func LoadSettings(ctx context.Context, dsSettings backend.DataSourceInstanceSettings) (Settings, error) {
+	settings := Settings{
 		Url:      dsSettings.URL,
 		User:     dsSettings.User,
 		Password: dsSettings.DecryptedSecureJSONData["password"],
 	}
 
-	err := json.Unmarshal(dsSettings.JSONData, settings)
+	err := json.Unmarshal(dsSettings.JSONData, &settings)
 	if err != nil {
-		return nil, err
+		return Settings{}, err
 	}
 
 	return settings, nil

--- a/pkg/models/settings_test.go
+++ b/pkg/models/settings_test.go
@@ -32,11 +32,6 @@ func TestLoadSettings(t *testing.T) {
 			t.Errorf("Unexpected error: %v", err)
 		}
 
-		if settings == nil {
-			t.Error("Expected non-nil settings")
-			return
-		}
-
 		if settings.Url != expected.Url {
 			t.Errorf("Unexpected URL. Expected: %s, got: %s", expected.Url, settings.Url)
 		}

--- a/pkg/models/settings_test.go
+++ b/pkg/models/settings_test.go
@@ -29,7 +29,7 @@ func TestLoadSettings(t *testing.T) {
 
 		settings, err := LoadSettings(ctx, dsSettings)
 		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
+			t.Error(err)
 		}
 
 		if settings.Url != expected.Url {

--- a/pkg/models/settings_test.go
+++ b/pkg/models/settings_test.go
@@ -1,0 +1,72 @@
+package models
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+func TestLoadSettings(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Returns settings with correct values", func(t *testing.T) {
+		dsSettings := backend.DataSourceInstanceSettings{
+			URL:  "localhost:5433",
+			User: "yugabyte",
+			DecryptedSecureJSONData: map[string]string{
+				"password": "1234",
+			},
+			JSONData: []byte(`{"database": "grafana"}`),
+		}
+
+		expected := &Settings{
+			Url:      "localhost:5433",
+			User:     "yugabyte",
+			Password: "1234",
+			Database: "grafana",
+		}
+
+		settings, err := LoadSettings(ctx, dsSettings)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		if settings == nil {
+			t.Error("Expected non-nil settings")
+			return
+		}
+
+		if settings.Url != expected.Url {
+			t.Errorf("Unexpected URL. Expected: %s, got: %s", expected.Url, settings.Url)
+		}
+
+		if settings.User != expected.User {
+			t.Errorf("Unexpected user. Expected: %s, got: %s", expected.User, settings.User)
+		}
+
+		if settings.Password != expected.Password {
+			t.Errorf("Unexpected password. Expected: %s, got: %s", expected.Password, settings.Password)
+		}
+
+		if settings.Database != expected.Database {
+			t.Errorf("Unexpected database. Expected: %s, got: %s", expected.Database, settings.Database)
+		}
+	})
+
+	t.Run("Returns error when JSON unmarshal fails", func(t *testing.T) {
+		dsSettings := backend.DataSourceInstanceSettings{
+			URL:  "localhost:5433",
+			User: "yugabyte",
+			DecryptedSecureJSONData: map[string]string{
+				"password": "1234",
+			},
+			JSONData: []byte(`invalid json`),
+		}
+
+		_, err := LoadSettings(ctx, dsSettings)
+		if err == nil {
+			t.Error("Expected error")
+		}
+	})
+}

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -53,9 +53,9 @@ func (ds *Datasource) query(ctx context.Context, pCtx backend.PluginContext, dat
 	}
 
 	if query.QueryType == "YSQL" {
-		response = ysql.Query(ctx, *settings, query)
+		response = ysql.Query(ctx, settings, query)
 	} else {
-		response = ycql.Query(ctx, *settings, query)
+		response = ycql.Query(ctx, settings, query)
 	}
 
 	return response
@@ -72,7 +72,7 @@ func (ds *Datasource) CheckHealth(ctx context.Context, req *backend.CheckHealthR
 		return fail, nil
 	}
 
-	response := ysql.Query(ctx, *settings, models.QueryModel{RawSql: "SELECT 42"})
+	response := ysql.Query(ctx, settings, models.QueryModel{RawSql: "SELECT 42"})
 
 	rowLen, err := response.Frames[0].RowLen()
 	if err != nil {

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -53,9 +53,9 @@ func (ds *Datasource) query(ctx context.Context, pCtx backend.PluginContext, dat
 	}
 
 	if query.QueryType == "YSQL" {
-		response = ysql.Query(ctx, *settings, *query)
+		response = ysql.Query(ctx, *settings, query)
 	} else {
-		response = ycql.Query(ctx, *settings, *query)
+		response = ycql.Query(ctx, *settings, query)
 	}
 
 	return response

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -14,7 +14,7 @@ func TestNewDatasource(t *testing.T) {
 
 	instance, err := NewDatasource(ctx, settings)
 	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
+		t.Error(err)
 	}
 
 	ds, ok := instance.(*Datasource)

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -2,27 +2,41 @@ package plugin
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
+func TestNewDatasource(t *testing.T) {
+	ctx := context.Background()
+	settings := backend.DataSourceInstanceSettings{}
+
+	instance, err := NewDatasource(ctx, settings)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	ds, ok := instance.(*Datasource)
+	if !ok {
+		t.Errorf("Unexpected instance type: %T", instance)
+	}
+
+	if !reflect.DeepEqual(ds.settings, settings) {
+		t.Errorf("Unexpected settings value: got %v, want %v", ds.settings, settings)
+	}
+}
+
 func TestQueryData(t *testing.T) {
 	ds := Datasource{}
+	request := &backend.QueryDataRequest{Queries: []backend.DataQuery{{RefID: "A"}}}
 
-	resp, err := ds.QueryData(
-		context.Background(),
-		&backend.QueryDataRequest{
-			Queries: []backend.DataQuery{
-				{RefID: "A"},
-			},
-		},
-	)
+	response, err := ds.QueryData(context.Background(), request)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if len(resp.Responses) != 1 {
+	if len(response.Responses) != 1 {
 		t.Fatal("QueryData must return a response")
 	}
 }

--- a/pkg/ysql/ysql.go
+++ b/pkg/ysql/ysql.go
@@ -29,12 +29,10 @@ func Query(ctx context.Context, settings models.Settings, query models.QueryMode
 }
 
 func ExecuteYSQL(ctx context.Context, settings models.Settings, query models.QueryModel) (*sql.Rows, error) {
-	host, port, err := net.SplitHostPort(settings.Url)
+	connection, err := buildConnectionString(settings)
 	if err != nil {
 		return nil, err
 	}
-
-	connection := fmt.Sprintf("host='%s' port='%s' database='%s' user='%s' password='%s' sslmode='allow'", host, port, settings.Database, settings.User, settings.Password)
 
 	db, err := sql.Open("pgx", connection)
 	if err != nil {
@@ -49,4 +47,13 @@ func ExecuteYSQL(ctx context.Context, settings models.Settings, query models.Que
 	}
 
 	return rows, nil
+}
+
+func buildConnectionString(settings models.Settings) (string, error) {
+	host, port, err := net.SplitHostPort(settings.Url)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("host='%s' port='%s' database='%s' user='%s' password='%s' sslmode='allow'", host, port, settings.Database, settings.User, settings.Password), nil
 }

--- a/pkg/ysql/ysql_test.go
+++ b/pkg/ysql/ysql_test.go
@@ -1,0 +1,32 @@
+package ysql
+
+import (
+	"testing"
+
+	"github.com/grafana/yugabyte/pkg/models"
+)
+
+func TestBuildConnectionString(t *testing.T) {
+	t.Run("Returns a connection string given valid settings", func(t *testing.T) {
+		settings := models.Settings{Url: "localhost:5433", Database: "grafana", User: "yugabyte", Password: "1234"}
+		expected := "host='localhost' port='5433' database='grafana' user='yugabyte' password='1234' sslmode='allow'"
+
+		result, err := buildConnectionString(settings)
+		if err != nil {
+			t.Errorf("Expected: %s, got: %s", expected, err)
+		}
+
+		if result != expected {
+			t.Errorf("Expected: %s, got: %s", expected, result)
+		}
+	})
+
+	t.Run("Returns an error when passed invalid URL", func(t *testing.T) {
+		settings := models.Settings{Url: "localhost", Database: "grafana", User: "yugabyte", Password: "1234"}
+
+		result, err := buildConnectionString(settings)
+		if err == nil {
+			t.Errorf("Expected: error missing port in address, got: %s", result)
+		}
+	})
+}

--- a/pkg/ysql/ysql_test.go
+++ b/pkg/ysql/ysql_test.go
@@ -13,7 +13,7 @@ func TestBuildConnectionString(t *testing.T) {
 
 		result, err := buildConnectionString(settings)
 		if err != nil {
-			t.Errorf("Expected: %s, got: %s", expected, err)
+			t.Error(err)
 		}
 
 		if result != expected {

--- a/src/components/ConfigEditor.test.tsx
+++ b/src/components/ConfigEditor.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { screen, render, fireEvent } from '@testing-library/react';
+import { ConfigEditor } from './ConfigEditor';
+import { DataSourceSettings } from '@grafana/data';
+import { YugabyteOptions } from 'types';
+
+describe('ConfigEditor', () => {
+  it('should render without errors', () => {
+    const MOCK_PROPS = generateMockProps();
+    render(<ConfigEditor {...MOCK_PROPS} />);
+    expect(screen.getByPlaceholderText('localhost:5433')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('yb_demo')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('yugabyte')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('********')).toBeInTheDocument();
+  });
+
+  it('should update the host url', () => {
+    const MOCK_PROPS = generateMockProps();
+    render(<ConfigEditor {...MOCK_PROPS} />);
+    const input = screen.getByPlaceholderText('localhost:5433');
+    fireEvent.change(input, { target: { value: 'new_host' } });
+    expect(MOCK_PROPS.onOptionsChange).toHaveBeenCalledWith(expect.objectContaining({ url: 'new_host' }));
+  });
+
+  it('should update the database', () => {
+    const MOCK_PROPS = generateMockProps();
+    render(<ConfigEditor {...MOCK_PROPS} />);
+    const input = screen.getByPlaceholderText('yb_demo');
+    fireEvent.change(input, { target: { value: 'new_database' } });
+    expect(MOCK_PROPS.onOptionsChange).toHaveBeenCalledWith(
+      expect.objectContaining({ jsonData: { database: 'new_database' } })
+    );
+  });
+
+  it('should update the username', () => {
+    const MOCK_PROPS = generateMockProps();
+    render(<ConfigEditor {...MOCK_PROPS} />);
+    const input = screen.getByPlaceholderText('yugabyte');
+    fireEvent.change(input, { target: { value: 'new_username' } });
+    expect(MOCK_PROPS.onOptionsChange).toHaveBeenCalledWith(expect.objectContaining({ user: 'new_username' }));
+  });
+
+  it('should update the password', () => {
+    const MOCK_PROPS = generateMockProps();
+    render(<ConfigEditor {...MOCK_PROPS} />);
+    const input = screen.getByPlaceholderText('********');
+    fireEvent.change(input, { target: { value: 'new_password' } });
+    fireEvent.blur(input);
+    expect(MOCK_PROPS.onOptionsChange).toHaveBeenCalledWith(
+      expect.objectContaining({ secureJsonData: { password: 'new_password' } })
+    );
+  });
+});
+
+interface MockProps {
+  options: DataSourceSettings<YugabyteOptions, {}>;
+  onOptionsChange: () => void;
+}
+
+const generateMockProps = (): MockProps => {
+  return {
+    options: {
+      url: '',
+      user: '',
+      jsonData: {},
+      secureJsonData: {},
+    } as DataSourceSettings<YugabyteOptions, {}>,
+    onOptionsChange: jest.fn(),
+  };
+};

--- a/src/components/QueryEditor.test.tsx
+++ b/src/components/QueryEditor.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryEditor } from './QueryEditor';
+import { YugabyteQuery } from 'types';
+import { DataSource } from 'datasource';
+
+describe('QueryEditor', () => {
+  it('should render without errors', async () => {
+    const MOCK_PROPS = generateMockProps();
+    render(<QueryEditor {...MOCK_PROPS} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+  });
+});
+
+interface MockProps {
+  datasource: DataSource;
+  query: YugabyteQuery;
+  onRunQuery: () => void;
+  onChange: () => void;
+}
+
+const generateMockProps = (): MockProps => {
+  return {
+    datasource: {} as DataSource,
+    query: {} as YugabyteQuery,
+    onRunQuery: jest.fn(),
+    onChange: jest.fn(),
+  };
+};

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import { QueryEditorProps } from '@grafana/data';
 import { SQLEditor } from '@grafana/experimental';
 import { DataSource } from '../datasource';
@@ -6,9 +6,7 @@ import { YugabyteOptions, YugabyteQuery } from '../types';
 
 type Props = QueryEditorProps<DataSource, YugabyteQuery, YugabyteOptions>;
 
-export function QueryEditor({ query, onChange, onRunQuery }: Props) {
-  useEffect(() => console.log(query), [query]);
-
+export function QueryEditor({ query, onChange }: Props) {
   const onRawQueryChange = useCallback(
     (rawSql: string, _: boolean) => {
       if (rawSql === query.rawSql) {


### PR DESCRIPTION
This PR implements some tests for the core functionality in the frontend and backend.

**Frontend Tests:** `ConfigEditor`, `QueryEditor`
**Backend Tests:** `NewDatasource`, `QueryData`, `LoadSettings`, `LoadQuery`, `BuildConnectionString`