### PR TITLE
remove forced type conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@emotion/css": "11.10.6",
     "@grafana/data": "10.0.3",
     "@grafana/experimental": "^1.7.7",
-    "@grafana/plugin-ui": "^0.6.3",
+    "@grafana/plugin-ui": "^0.7.0",
     "@grafana/runtime": "10.0.3",
     "@grafana/schema": "10.0.3",
     "@grafana/ui": "10.0.3",

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,8 +1,6 @@
 import {
   DataFrame,
   DataFrameView,
-  DataQueryRequest,
-  DataQueryResponse,
   DataSourceInstanceSettings,
   TimeRange,
 } from '@grafana/data';
@@ -16,8 +14,8 @@ import {
 import { LanguageCompletionProvider } from '@grafana/experimental';
 import { DB, QueryFormat, SQLSelectableValue, ValidationResults } from '@grafana/plugin-ui';
 import { DataQuery } from '@grafana/schema';
-import { Observable, lastValueFrom, map } from 'rxjs';
-import { YugabyteQuery, YugabyteOptions, SqldsQueryFormat } from 'types';
+import { lastValueFrom, map } from 'rxjs';
+import { YugabyteQuery, YugabyteOptions } from 'types';
 import { buildColumnQuery, buildTableQuery } from './utils/queries';
 import { completionFetchColumns, completionFetchTables, getCompletionProvider } from './utils/completion';
 import { toRawSql } from './utils/sql';
@@ -36,21 +34,6 @@ export class YugabyteDataSource extends DataSourceWithBackend<YugabyteQuery, Yug
   }
 
   /**
-   * Executes a query request and returns the response.
-   * Transforms the query format to so it can be recognized by sqlds.
-   */
-  query(request: DataQueryRequest<YugabyteQuery>): Observable<DataQueryResponse> {
-    const targets = request.targets.map((target) => {
-      if (target.format === 'time_series') {
-        return { ...target, format: SqldsQueryFormat.TimeSeries as unknown as QueryFormat };
-      } else {
-        return { ...target, format: SqldsQueryFormat.Table as unknown as QueryFormat };
-      }
-    });
-    return super.query({ ...request, targets: targets });
-  }
-
-  /**
    * Validates a Yugabyte query.
    * Returns a ValidationResults object.
    */
@@ -66,7 +49,7 @@ export class YugabyteDataSource extends DataSourceWithBackend<YugabyteQuery, Yug
     const frame = await this.runMetaQuery(
       {
         rawSql: query,
-        format: SqldsQueryFormat.Table as unknown as QueryFormat,
+        format: QueryFormat.Table,
         refId: options?.refId,
       },
       options

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,11 +16,3 @@ export interface YugabyteOptions extends SQLOptions {}
 export interface YugabyteSecureJsonData {
   password?: string;
 }
-
-/**
- * The format of a query result.
- */
-export enum SqldsQueryFormat {
-  TimeSeries = 0,
-  Table = 1,
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1846,10 +1846,10 @@
     ua-parser-js "^1.0.32"
     web-vitals "^3.1.1"
 
-"@grafana/plugin-ui@^0.6.3":
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/@grafana/plugin-ui/-/plugin-ui-0.6.3.tgz#2e6b8a37584ef2e79ec806f5689e552db9417cee"
-  integrity sha512-SkPF0YE7Q4rRazaNkkA0UsUDp2S0jN+3F8O4daHRFCyH4ZwiEF82G6MYLgDs1NRr3SGqJ/SBOZHn6lu9+Khnzg==
+"@grafana/plugin-ui@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@grafana/plugin-ui/-/plugin-ui-0.7.0.tgz#e17b9e5311f949e1365ea967584386f398fd0361"
+  integrity sha512-KYbXqx1WdXmm3fzvh77aIkn3zjyiCy4nKekWIDubVWaCSEn4CV9fyPrD925UnVwKZ9ZgJp66INdJTnGBULxA3w==
   dependencies:
     "@changesets/read" "^0.5.9"
     "@changesets/write" "^0.2.3"


### PR DESCRIPTION
with the following pr merged in plugin-ui (https://github.com/grafana/plugin-ui/pull/94) we no longer need to force a type conversion.

this pr bumps to the latest release of plugin-ui, and removes the forced type conversion.