### PR TITLE
Fix rxjs version incompatibility and type error

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@grafana/ui": "10.4.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "rxjs": "7.8.0",
+    "rxjs": "7.8.1",
     "tslib": "2.5.3"
   },
   "resolutions": {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -58,7 +58,7 @@ export class YugabyteDataSource extends DataSourceWithBackend<YugabyteQuery, Yug
    * Executes a SQL query and returns the result as a DataFrameView.
    * Used for running meta queries to fetch table and column names.
    */
-  async runSql<T>(query: string, options?: RunSQLOptions): Promise<DataFrameView<T>> {
+  async runSql<T extends object>(query: string, options?: RunSQLOptions): Promise<DataFrameView<T>> {
     const frame = await this.runMetaQuery(
       {
         rawSql: query,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7674,13 +7674,6 @@ rw@1, rw@^1.3.3:
   resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
   integrity sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
 
-rxjs@7.8.0:
-  version "7.8.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.0.tgz#90a938862a82888ff4c7359811a595e14e1e09a4"
-  integrity sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==
-  dependencies:
-    tslib "^2.1.0"
-
 rxjs@7.8.1:
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"


### PR DESCRIPTION
This PR addresses code errors:

1. **Mismatched rxjs versions** - The plugin had a type incompatibility due to mismatched rxjs versions between the plugins version of rxjs and the version in grafana/data.

2. **Type constraint error** - A type error occurred in the codebase `Type 'T' does not satisfy the constraint 'object'`
