### PR TITLE
Enable annotations in plugin metadata

### DIFF
--- a/.changeset/enable-annotations-meta.md
+++ b/.changeset/enable-annotations-meta.md
@@ -1,0 +1,5 @@
+---
+'yugabyte': patch
+---
+
+Enable annotations in plugin metadata so the data source appears in the annotation query editor

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -6,6 +6,7 @@
   "metrics": true,
   "backend": true,
   "alerting": true,
+  "annotations": true,
   "executable": "gpx_yugabyte",
   "info": {
     "description": "Yugabyte datasource plugin for grafana",


### PR DESCRIPTION
## Summary
- Set `"annotations": true` in `plugin.json` so Grafana shows Yugabyte in the dashboard annotation query editor
- Runtime support (`annotations = {}` in `datasource.ts`) was already present; only the plugin capability flag was missing
- Adds a changeset for the patch release note

## Test plan
- [ ] Install/build plugin from this branch against Grafana
- [ ] Open Dashboard settings → Annotations → Add annotation query
- [ ] Confirm Yugabyte appears in the data source picker
- [ ] Create a simple annotation query returning `time` and `text` columns and confirm markers render